### PR TITLE
Extract historical campaign data

### DIFF
--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -307,7 +307,20 @@ def get_account_ad_performance_for_single_day(ad_account: adaccount.AdAccount,
                 'level': 'ad',
                 'limit': 1000,
                 'time_range': {'since': single_date.strftime('%Y-%m-%d'),
-                               'until': single_date.strftime('%Y-%m-%d')}})
+                               'until': single_date.strftime('%Y-%m-%d')},
+                # By default only ACTIVE campaigns get considered.
+                'filtering': [{
+                    'field': 'ad.effective_status',
+                    'operator': 'IN',
+                    'value': ['ACTIVE',
+                              'PAUSED',
+                              'PENDING_REVIEW',
+                              'DISAPPROVED',
+                              'PREAPPROVED',
+                              'PENDING_BILLING_INFO',
+                              'CAMPAIGN_PAUSED',
+                              'ARCHIVED',
+                              'ADSET_PAUSED']}]})
 
     return ad_insights
 


### PR DESCRIPTION
- By default `get_insights()` only breaks down by active ads. To correctly report historical campaign which might have status other than `ACTIVE` (e.g. `ARCHIVED`, `DELETED`, etc...) we need to explicity include them in the `get_insights()` call.
- See: https://developers.facebook.com/docs/marketing-api/insights/v2.9