### PR TITLE
Add target accounts parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 *2017-10-05*
 
 - Add the `target_accounts` parameter to optionally limit the accounts to download
-
+- Updated `facebookads` to 2.10.1`
 
 ## 1.2.0
 *2017-09-21*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+*2017-10-05*
+
+- Add the `target_accounts` parameter to optionally limit the accounts to download
+
+
 ## 1.2.0
 *2017-09-21*
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Select the app you want to use to download the data, activate the `read_insights
 The generated `access_token` is then shown to you:
 ![Facebook System User Access Token](docs/facebook-system-user-access-token.png)
 
+Currently Facebook requires you to perform a number of successful API calls before being able to access more than 5 accounts. If that's the case use the `target_accounts` parameter to specify these 5 accounts and avoid API errors.
+
 ## Usage
 
 To run the Facebook Ads Performance Downloader call `download-facebook-performance-data` with its config parameters:  
@@ -142,4 +144,8 @@ For all options, see
                                 Example: "2015-01-01"
       --redownload_window TEXT  The number of days for which the performance data
                                 will be redownloaded. Example: "28"
+      --target_accounts TEXT    The accounts to download, comma separated, if not
+                                set or empty each available account will be tried.
+                                Example: ""
+
       --help                    Show this message and exit.

--- a/facebook_downloader/cli.py
+++ b/facebook_downloader/cli.py
@@ -28,6 +28,7 @@ def apply_options(kwargs):
 @config_option(config.data_dir)
 @config_option(config.first_date)
 @config_option(config.redownload_window)
+@config_option(config.target_accounts)
 def download_data(**kwargs):
     """
     Downloads data.

--- a/facebook_downloader/config.py
+++ b/facebook_downloader/config.py
@@ -43,6 +43,7 @@ def redownload_window() -> str:
     """The number of days for which the performance data will be redownloaded"""
     return '28'
 
+
 def target_accounts() -> str:
     """The accounts to download, comma separated, if empty each available account will be tried"""
     return ''

--- a/facebook_downloader/config.py
+++ b/facebook_downloader/config.py
@@ -42,3 +42,7 @@ def access_token() -> str:
 def redownload_window() -> str:
     """The number of days for which the performance data will be redownloaded"""
     return '28'
+
+def target_accounts() -> str:
+    """The accounts to download, comma separated, if empty each available account will be tried"""
+    return ''

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -30,9 +30,9 @@ def download_data():
     ad_accounts = _get_ad_accounts()
     target_accounts = list(filter(None, config.target_accounts().split(',')))
     if len(target_accounts) > 0:
-        logging.info('the app can see %s accounts but the configuration specified only %s target accounts: %s' , len(ad_accounts), len(target_accounts), ', '.join(target_accounts))
+        logging.info('the app can see %s accounts but the configuration specified only %s target accounts: %s', len(ad_accounts), len(target_accounts), ', '.join(target_accounts))
         ad_accounts = [ad_account for ad_account in ad_accounts if ad_account['account_id'] in config.target_accounts()]
-        logging.info('after filtering {} accounts will be downloaded'.format(len(ad_accounts)))
+        logging.info('after filtering %s accounts will be downloaded: %s', len(ad_accounts), ', '.join(ad_accounts))
     download_data_sets(ad_accounts)
 
 

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -28,6 +28,11 @@ def download_data():
                         config.app_secret(),
                         config.access_token())
     ad_accounts = _get_ad_accounts()
+    target_accounts = list(filter(None, config.target_accounts().split(',')))
+    if len(target_accounts) > 0:
+        logging.info('the app can see {} accounts but the configuration requested filtering for {} target accounts'.format(len(ad_accounts), len(target_accounts)))
+        ad_accounts = [ad_account for ad_account in ad_accounts if ad_account['account_id'] in config.target_accounts()]
+        logging.info('after filtering {} accounts will be downloaded'.format(len(ad_accounts)))
     download_data_sets(ad_accounts)
 
 

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -30,7 +30,7 @@ def download_data():
     ad_accounts = _get_ad_accounts()
     target_accounts = list(filter(None, config.target_accounts().split(',')))
     if len(target_accounts) > 0:
-        logging.info('the app can see {} accounts but the configuration requested filtering for {} target accounts'.format(len(ad_accounts), len(target_accounts)))
+        logging.info('the app can see %s accounts but the configuration specified only %s target accounts: %s' , len(ad_accounts), len(target_accounts), ', '.join(target_accounts))
         ad_accounts = [ad_account for ad_account in ad_accounts if ad_account['account_id'] in config.target_accounts()]
         logging.info('after filtering {} accounts will be downloaded'.format(len(ad_accounts)))
     download_data_sets(ad_accounts)

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -87,7 +87,8 @@ def download_ad_performance(ad_accounts: [adaccount.AdAccount]):
         ad_accounts: A list of all ad accounts to download.
 
     """
-    for ad_account in ad_accounts:
+    for account_index, ad_account in enumerate(ad_accounts):
+        logging.info('Downloading data for account %s (account %d of %d)', ad_account['account_id'], account_index, len(ad_accounts))
         # calculate yesterday based on the timezone of the ad account
         ad_account_timezone = datetime.timezone(datetime.timedelta(
             hours=float(ad_account['timezone_offset_hours_utc'])))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='facebook-ads-performance-downloader',
-    version='1.2.0',
+    version='1.3.0',
 
     description=("Downloads data from the Facebook Ads API to local files"),
 


### PR DESCRIPTION
It seems the Facebook APIs require a certain number of successful requests using the lowest level access before being able to upgrade and be able to download more than 5 accounts.

If we run the downloader currently it tries to download each account and fails and so we can't request an account upgrade, which is necessary to download each account in first place.

This PR let the user define an optional list of accounts to download and explains the issue in the README.