### PR TITLE
Add: check for 'Job Failed' status

### DIFF
--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -337,7 +337,7 @@ def get_account_ad_performance_for_single_day(ad_account: adaccount.AdAccount,
     # https://developers.facebook.com/docs/marketing-api/asyncrequests/
     async_job = ad_account.get_insights(fields=fields, params=params, async=True)
     async_job.remote_read()
-    while async_job[AdReportRun.Field.async_percent_completion] < 100:
+    while async_job[AdReportRun.Field.async_percent_completion] < 100 and async_job[AdReportRun.Field.async_status] != 'Job Failed':
         time.sleep(1)
         async_job.remote_read()
     time.sleep(1)


### PR DESCRIPTION
For async jobs also check if AdReportRun.Field.async_status is not
'Job Failed'. There have been instances where this does occur without
it generating an exception while leaving async_percent_completion at
zero, resulting in an infinte loop. Implementing it like this should
take care of this case while also triggering a retry due to
get_result() failing with: "Sorry, the report cannot be loaded
successfully. Please check if your job status is completed instead
of failed or running before fetching the data.".