### PR TITLE
Parallelisation of the ad performance download

### DIFF
--- a/facebook_downloader/cli.py
+++ b/facebook_downloader/cli.py
@@ -28,6 +28,7 @@ def apply_options(kwargs):
 @config_option(config.first_date)
 @config_option(config.redownload_window)
 @config_option(config.target_accounts)
+@config_option(config.number_of_ad_performance_threads)
 def download_data(**kwargs):
     """
     Downloads data.

--- a/facebook_downloader/config.py
+++ b/facebook_downloader/config.py
@@ -47,3 +47,7 @@ def redownload_window() -> str:
 def target_accounts() -> str:
     """The accounts to download, comma separated, if empty each available account will be tried"""
     return ''
+
+def number_of_ad_performance_threads() -> str:
+    """The number of threads used to download ad performance"""
+    return '10'

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -1,10 +1,15 @@
 import datetime
 import errno
+import heapq
 import json
 import logging
 import re
 import sqlite3
+import sys
+import threading
 import time
+import timeit
+import typing
 from functools import wraps
 from pathlib import Path
 from typing import Generator, List, Union
@@ -94,9 +99,8 @@ def download_ad_performance(ad_accounts: [adaccount.AdAccount]):
         ad_accounts: A list of all ad accounts to download.
 
     """
-    for account_index, ad_account in enumerate(ad_accounts):
-        logging.info('Downloading data for account %s (account %d of %d)', ad_account['account_id'], account_index,
-                     len(ad_accounts))
+    job_list: List[JobQueueItem] = list()
+    for ad_account in ad_accounts:
         # calculate yesterday based on the timezone of the ad account
         ad_account_timezone = datetime.timezone(datetime.timedelta(
             hours=float(ad_account['timezone_offset_hours_utc'])))
@@ -113,11 +117,10 @@ def download_ad_performance(ad_accounts: [adaccount.AdAccount]):
 
             if (not db_name.is_file()
                     or (last_date - current_date).days <= int(config.redownload_window())):
-                ad_insights = get_account_ad_performance_for_single_day(ad_account,
-                                                                        current_date)
-                with sqlite3.connect(str(db_name)) as con:
-                    _upsert_ad_performance(ad_insights, con)
+                job_list.append(JobQueueItem(ad_account['account_id'], current_date, str(db_name)))
             current_date -= datetime.timedelta(days=1)
+
+    process_single_day_jobs_concurrently(job_list, int(config.number_of_ad_performance_threads()))
 
 
 def download_account_structure_per_account(ad_account: adaccount.AdAccount) \
@@ -285,7 +288,6 @@ def get_campaign_data(ad_account: adaccount.AdAccount) -> {}:
     return result
 
 
-@rate_limiting
 def get_account_ad_performance_for_single_day(ad_account: adaccount.AdAccount,
                                               single_date: datetime) -> adsinsights.AdsInsights:
     """Downloads the ad performance for an ad account for a given day
@@ -299,10 +301,6 @@ def get_account_ad_performance_for_single_day(ad_account: adaccount.AdAccount,
         A list containing dictionaries with the ad performance from the report
 
     """
-    logging.info('download Facebook ad performance of act_{ad_account_id} on {single_date}'.format(
-        ad_account_id=ad_account['account_id'],
-        single_date=single_date.strftime('%Y-%m-%d')))
-
     fields = ['date_start',
               'ad_id',
               'impressions',
@@ -507,3 +505,232 @@ def _first_download_date_of_ad_account(ad_account: adaccount.AdAccount) -> datet
         return max(config_first_date, account_created_date)
     else:
         return config_first_date
+
+
+class JobQueueItem:
+
+    def __init__(self: 'JobQueueItem', ad_account_id: str, date: datetime.datetime,
+                 db_name: str) -> None:
+        self.ad_account_id: str = ad_account_id
+        self.date: datetime.datetime = date
+        self.db_name = db_name
+        self.try_count: int = 0
+
+    def __lt__(self: 'JobQueueItem', other: 'JobQueueItem') -> bool:
+        # python heapq sorts lowest to highest
+
+        if self.try_count > other.try_count:
+            return True
+        elif self.try_count < other.try_count:
+            return False
+
+        if self.date > other.date:
+            return True
+
+        return False
+
+class RetryQueueItem:
+    def __init__(self: 'RetryQueueItem', retry_at: datetime.datetime, job: JobQueueItem) -> None:
+        self.retry_at: datetime.datetime = retry_at
+        self.job = job
+
+    def __lt__(self: 'RetryQueueItem', other: 'RetryQueueItem') -> bool:
+        return self.retry_at < other.retry_at
+
+class ThreadArgs:
+
+    def __init__(self: 'ThreadArgs', job_list: typing.List[JobQueueItem]) -> None:
+        self.job_list: typing.List[JobQueueItem] = job_list
+        self.retry_queue: typing.List[RetryQueueItem] = list()
+        self.jobs_left = len(job_list)
+
+        # both cvs do no require the same mutex, but it is slightly more convenient than using
+        # events and manually locking where needed
+        self.job_list_cv: threading.Condition = threading.Condition()
+        self.state_changed_cv: threading.Condition = threading.Condition()
+
+        self.retry_queue_cv: threading.Condition = threading.Condition()
+        self.logging_mutex: threading.Lock = threading.Lock()
+        self.error_occured: bool = False
+        self.done: bool = False
+
+
+def process_single_day_jobs_concurrently(job_list: typing.List[JobQueueItem], n_threads: int) -> None:
+    if n_threads < 1:
+      raise ValueError('process_single_day_jobs_concurrently should have n_threads > 0')
+    heapq.heapify(job_list)
+    thread_args: ThreadArgs = ThreadArgs(job_list)
+    # store the default API since the worker threads will change it
+    default_api: FacebookAdsApi = FacebookAdsApi.get_default_api()
+
+    thread_list: typing.List[threading.Thread] = list()
+    thread: threading.Thread = threading.Thread(target = retry_thread_func, args = (thread_args, ))
+    thread_list.append(thread)
+    thread.start()
+    for i in range(0, n_threads):
+        thread = threading.Thread(target = job_thread_func, args = (thread_args,))
+        thread_list.append(thread)
+        thread.start()
+
+    thread_args.state_changed_cv.acquire()
+    try:
+        while (not thread_args.error_occured) and (thread_args.jobs_left > 0):
+            thread_args.state_changed_cv.wait()
+    except:
+        thread_args.error_occured = True
+    finally:
+        thread_args.done = True
+        thread_args.state_changed_cv.release()
+        # notify all waiting threads, so they can see that they are done
+        # release -> aquire ordering matters due to potential deadlocking
+        with thread_args.job_list_cv:
+            thread_args.job_list_cv.notify_all()
+        with thread_args.retry_queue_cv:
+            thread_args.retry_queue_cv.notify()
+
+    with thread_args.logging_mutex:
+        logging.info('waiting for all threads to exit'.format(threading.get_ident()))
+    for thread in thread_list:
+        thread.join()
+
+    # restore the default API in case something else needs it after this function
+    FacebookAdsApi.set_default_api(default_api)
+
+    if thread_args.error_occured:
+        sys.exit(1)
+
+def job_thread_func(args: ThreadArgs) -> None:
+    job: typing.Optional[JobQueueItem]
+    # Api objects do not seem thread safe at all, create on per thread and nuke the default for
+    # good measure
+    api: FacebookAdsApi = FacebookAdsApi.init(config.app_id(),
+                                              config.app_secret(),
+                                              config.access_token())
+    FacebookAdsApi.set_default_api(None)
+    # No need to lock since this can only change to True, so  worst case this does one extra
+    # iteration. Also assignment / reading of booleans should be atomic anyway.
+    while not args.done:
+
+        job = get_job_from_queue(args)
+        if job is None:
+            continue
+
+        process_job(args, job, api)
+
+    log(logging.info, args.logging_mutex, ['thread {0} exited'.format(threading.get_ident())])
+
+def get_job_from_queue(args: ThreadArgs) -> typing.Optional[JobQueueItem]:
+    with args.job_list_cv:
+        # wait for a job to become available
+        while len(args.job_list) <= 0:
+            args.job_list_cv.wait()
+            # check if everything is done in order to avoid infinite loops when no new
+            # jobs are added to the queue
+            if (args.done):
+                return None
+        return heapq.heappop(args.job_list)
+
+def process_job(args: ThreadArgs, job: JobQueueItem, api: FacebookAdsApi) -> None:
+    account_id: str = job.ad_account_id
+    date_str: str = job.date.strftime('%Y-%m-%d')
+    job.try_count += 1
+    job_info_str: str = 'act_{ad_account_id} on {single_date}'.format(ad_account_id=account_id,
+                                                                      single_date=date_str)
+    log(logging.info, args.logging_mutex, ['download Facebook ad performance of {job}'
+            ' - attempt #{attempt}'.format(job = job_info_str, attempt = job.try_count)])
+
+    # platform specific timer
+    start = timeit.default_timer()
+
+    request_error_occured: bool = False
+    error_occured: bool = False
+    error_msg: typing.List[str] = list()
+    ad_insights: adsinsights.AdsInsights
+    try:
+        ad_account = adaccount.AdAccount('act_' + account_id, api = api)
+        ad_insights = get_account_ad_performance_for_single_day(ad_account, job.date)
+        with sqlite3.connect(job.db_name) as con:
+            _upsert_ad_performance(ad_insights, con)
+
+        end = timeit.default_timer()
+
+        log(logging.info, args.logging_mutex, ['finished download Facebook ad performance of {job}'
+        ' in {time}s - attempt #{attempt}'.format(job = job_info_str,
+                                                  time=round(end - start, 2),
+                                                  attempt = job.try_count)])
+
+        with args.state_changed_cv:
+            args.jobs_left -= 1
+            if args.jobs_left == 0:
+                args.state_changed_cv.notify()
+
+    except FacebookRequestError as e:
+        request_error_occured = True
+        error_msg.append(e.get_message())
+        error_msg.append(e.api_error_message())
+    except Exception as e:
+        error_occured = True
+        error_msg.append(str(e))
+
+    if request_error_occured:
+        if job.try_count < 8:
+            duration: int = 60 * 2 ** (job.try_count - 1)
+            retry_at: datetime.datetime = datetime.datetime.now() + datetime.timedelta(
+                    seconds = duration)
+            retry_msg: str = 'retrying {job} in {duration} seconds - attempt #{attempt}'.format(
+                    job = job_info_str, attempt = job.try_count, duration = duration)
+            error_msg.append(retry_msg)
+            with args.retry_queue_cv:
+                heapq.heappush(args.retry_queue, RetryQueueItem(retry_at, job))
+                args.retry_queue_cv.notify_all()
+            log(logging.warning, args.logging_mutex, error_msg)
+            return
+        else:
+            error_occured = True
+            error_msg.append('download of {job} failed too many times'.format(job = job_info_str))
+
+    if error_occured:
+        log(logging.error, args.logging_mutex, error_msg)
+
+        with args.state_changed_cv:
+            # technically does not require locking but it is needed for the notify to work
+            # so might as well put this in scope
+            args.error_occured = True
+            args.done = True
+            args.state_changed_cv.notify()
+
+        return
+
+
+def retry_thread_func(args: ThreadArgs) -> None:
+    # locking outside the main loop is fine here, since wait will relinquish the lock
+    with args.retry_queue_cv:
+        while not args.done:
+            wait_timeout: typing.Optional[float] = None
+            if len(args.retry_queue) > 0:
+                now: datetime.datetime = datetime.datetime.now()
+                top: typing.Optional[RetryQueueItem] = args.retry_queue[0]
+                # duplicate check, but this prevents mutex contention when it is not required
+                if (not top is None) and (now >= top.retry_at):
+                    # note: this will not deadlock since none of the other code locks
+                    # retry_queue_cv and job_list_cv nested in reverse order
+                    with args.job_list_cv:
+                        while (not top is None) and (now >= top.retry_at):
+                            current_job: JobQueueItem = heapq.heappop(args.retry_queue).job
+                            heapq.heappush(args.job_list, current_job)
+                            if len(args.retry_queue) > 0:
+                                top = args.retry_queue[0]
+                            else:
+                                top = None
+                        args.job_list_cv.notify()
+
+                if not top is None:
+                    wait_timeout = (top.retry_at - now).total_seconds()
+
+            args.retry_queue_cv.wait(wait_timeout)
+
+def log(log_func: typing.Callable[[str], None], logging_mutex: threading.Lock,
+        log_strs: typing.List[str]):
+    with logging_mutex:
+        for log_str in log_strs:
+            log_func(log_str)


### PR DESCRIPTION
Some words about the implementation. Before anything happens a job queue is
created for all the download requests that need to happen. This queue is sorted
by try_count and date (both descending). Threads just pick the top item from
the job queue and process it accordingly. This could lead to some heavy
contention if you specify a crazy amount of threads and your downloads finish
quite fast.  I however did not find a need to let threads grab a whole chunk of
jobs at once, especially since jobs can be re-added to the queue. If a job
fails it will be added to a retry queue (sorted by retry_date ascending), a
single thread will pop this queue after waiting the specified amount of time
and will re-add the job back into to job queue. Due to the aforementioned
ordering of this queue failed jobs get increasing priority over other jobs
based on their try_count.

Note: this is implemented using threading, this does mean it is not quite
parallel due to the global interpreter lock that is present in Python. How ever
is should not matter too much here, since all of the downloading is IO bound
rather than CPU bound.