### PR TITLE
Slow down the worker thread when API quota exceded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info/
 __pycache__
 .venv/
+.vscode/

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -710,6 +710,9 @@ def _process_job(args: ThreadArgs, job: JobQueueItem, api: FacebookAdsApi) -> No
                 heapq.heappush(args.retry_queue, RetryQueueItem(retry_at, job))
                 args.retry_queue_cv.notify_all()
             _log(logging.warning, args.logging_mutex, error_msg)
+            # Also sleep. What good is scheduling a job for later when the request quota is exceded and the API still gets bombarded
+            # with uninterrupted requests?
+            time.sleep(duration)
             return
         else:
             error_occured = True


### PR DESCRIPTION
Currently, individual jobs are postponed in execution, but workers have a full queue that they're constantly trying to send, thus negating the brake system put in place to slow them down when this happens.
This ensures the thread(s) are also waiting, to eliminate the chance that the downloader will ultimately fail. As long as there are not many parallel threads working.