### PR TITLE
Updated to facebook api 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1 (2019-08-20)
+- Switch to current Facebook API version (4.0.2) 
+- Replaced deprecated function remote_read with api_get
+
 ## 3.0.0 (2019-04-13)
 
 - Change MARA_XXX variables to functions to delay importing of imports

--- a/facebook_downloader/downloader.py
+++ b/facebook_downloader/downloader.py
@@ -355,11 +355,11 @@ def get_account_ad_performance_for_single_day(ad_account: adaccount.AdAccount,
     # https://developers.facebook.com/docs/marketing-api/insights/best-practices
     # https://developers.facebook.com/docs/marketing-api/asyncrequests/
     async_job = ad_account.get_insights(fields=fields, params=params, is_async=True)
-    async_job.remote_read()
+    async_job.api_get()
     while async_job[AdReportRun.Field.async_percent_completion] < 100 or async_job[
         AdReportRun.Field.async_status] != 'Job Completed':
         time.sleep(1)
-        async_job.remote_read()
+        async_job.api_get()
     time.sleep(1)
 
     ad_insights = async_job.get_result()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='facebook-ads-performance-downloader',
-    version='3.0.0',
+    version='3.0.1',
 
     description=("Downloads data from the Facebook Ads API to local files"),
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description=("Downloads data from the Facebook Ads API to local files"),
 
     install_requires=[
-        'facebook_business==3.3',
+        'facebook_business==4.0.2',
         'click>=6.0',
         'wheel>=0.29'
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description=("Downloads data from the Facebook Ads API to local files"),
 
     install_requires=[
-        'facebook_business==3.2.4',
+        'facebook_business==3.3',
         'click>=6.0',
         'wheel>=0.29'
     ],


### PR DESCRIPTION
3.0.1 (2019-08-20)
- Switch to current Facebook API version (4.0.2) 
- Replaced deprecated function remote_read with api_get