### PR TITLE
Facebook business version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.0 (2021-10-11)
+
+- Switch to current Facebook API version (11.0.0)
+
 ## 3.2.0 (2021-04-19)
 
 - Switch to current Facebook API version (10.0.0)

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='facebook-ads-performance-downloader',
-    version='3.2.0',
+    version='3.3.0',
 
     description=("Downloads data from the Facebook Ads API to local files"),
 
     install_requires=[
-        'facebook_business==10.0.0',
+        'facebook_business==11.0.0',
         'click>=6.0',
         'wheel>=0.29'
     ],


### PR DESCRIPTION
V10 of facebook business is deprecated and can't be used anymore. Therefore the update for facebook business 11.0.0.